### PR TITLE
Add secrets scanning workflow

### DIFF
--- a/.github/workflows/secrets-scanner.yaml
+++ b/.github/workflows/secrets-scanner.yaml
@@ -1,0 +1,72 @@
+name: TruffleHog Secrets Scan
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 4 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  TruffleHog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # Special check which ensures that the clone performed above is not shallow. We need the
+      # complete git history for scanning to work correctly in all the situations. In some cases
+      # if a shallow clone is used, trufflehog won't not fail with an error, but it would simply
+      # not detect any files and that could be dangerous.
+      - name: Shallow repo check
+        run: |
+          if git rev-parse --is-shallow-repository | grep -q "true"; then
+            echo "Encountered a shallow repository, trufflehog may not work as expected!"
+            exit 1
+          fi
+
+      - name: scan-pr
+        uses: trufflesecurity/trufflehog@main
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --debug --only-verified
+
+      - name: scan-push
+        uses: trufflesecurity/trufflehog@main
+        if: ${{ github.event_name == 'push' }}
+        with:
+          path: ./
+          base: ""
+          head: ${{ github.ref_name }}
+          extra_args: --debug --only-verified
+
+      # As part of cron trigger we scan the whole repo directory.
+      # NOTE: Since trufflehog GHA is meant to be used in context of push / pr it can't be
+      # used dorectly to scan the whole repo directory. This may take a while, but it's good idea
+      # to run it on a daily basis.
+      - name: scan-cron
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          docker run --rm -v "$PWD:/workdir" trufflesecurity/trufflehog:latest git \
+            file:///workdir --fail --no-update --debug --only-verified
+
+      - name: Notify Slack on Failure
+        if: ${{ failure() && github.ref_name == 'main' }}
+        uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#eng-dataset-o11y'


### PR DESCRIPTION
This pull request adds a workflow which uses trufflehog to automatically scan files and commits for secrets on push, PR and as part of a daily cron trigger.