### PR TITLE
DPDV-2604 - fix validation, add missing custom alert HTML config page

### DIFF
--- a/TA_dataset/default/data/ui/alerts/dataset_event.html
+++ b/TA_dataset/default/data/ui/alerts/dataset_event.html
@@ -1,0 +1,4 @@
+<form class="form-horizontal form-complex">
+    <h1>Custom Dataset alert action UI configuration</h1>
+    <p>TODO</p>
+</form>


### PR DESCRIPTION
# Description
fixed inspection validation via adding empty custom alert HTML page

# Testing

verified via splunk-appinspect inspect TA_dataset --included-tags splunk_appinspect, see output (no failures)

```
TA_dataset Report Summary:

         error:  2
       failure:  0
       skipped:  0
  manual_check: 19
not_applicable: 96
       warning:  2
       success: 145
-------------------
         Total: 264
```