### PR TITLE
DPDV-2608: Introduce alias s1query

### DIFF
--- a/TA_dataset/default/commands.conf
+++ b/TA_dataset/default/commands.conf
@@ -2,3 +2,8 @@
 filename = dataset_search_command.py
 chunked = true
 python.version = python3
+
+[s1query]
+filename = dataset_search_command.py
+chunked = true
+python.version = python3

--- a/TA_dataset/default/searchbnf.conf
+++ b/TA_dataset/default/searchbnf.conf
@@ -1,5 +1,6 @@
 [dataset-command]
 syntax = dataset (account=<string>)? <method>? (search=<string>)? (columns=<string>)? (maxcount=<integer>)? (starttime=<string>)? (endtime=<string>)? (field=<string>)? (function=<string>)? (buckets=<int>)? (createsummaries=<bool>)? (onlyusesummaries=<bool>)?
+alias = s1query
 shortdesc = Connects to the DataSet API and executes a search.
 description =  This command connects to the DataSet API and executes a search, and a Splunk event is generated for each result. startTime and endTime are optional alternatives to the Splunk time picker. field only applies to facet; function, buckets, createSummaries and onlyUseSummaries only apply to timeseriesQueries.
 comment1 = Search the last 10 minutes for for Action='allow' from any serverHost and return 5,000 results.
@@ -13,7 +14,10 @@ example4 = | dataset method=facet search="serverHost = *" field=serverHost maxco
 usage = public
 tags = dataset sentinelone api
 maintainer = mike.mcgrail@sentinelone.com
-category = generating
+
+# this key no longer exists
+# https://docs.splunk.com/Documentation/Splunk/9.1.0/Admin/Searchbnfconf
+# category = generating
 
 [method]
 syntax=method=(query|powerquery|facet|timeseries)

--- a/e2e/examples.spec.ts
+++ b/e2e/examples.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { goToDataSet } from './utils';
+import { goToDataSet, goToExamples, waitForData } from './utils';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
 
   await goToDataSet(page);
+  await goToExamples(page);
 });
 
 
@@ -18,28 +19,7 @@ test('Check example page', async ({ page }) => {
   // wait for elements to load
   await expect(page.getByRole("main").getByText("4. Timeseries Query: This will calculate numeric values over time.")).toHaveCount(1)
 
-  // Wait for the "Waiting for data..." text to disappear
-  console.log("Wait for 'Waiting for data' to disappear")
-  await page.screenshot({ path: 'playwright-screenshots/page-examples-before-waiting-for-data.png', fullPage: true });
-  await expect(page.getByText(/Waiting for data/)).toHaveCount(0, {timeout: 15000});
-
-  await page.screenshot({ path: 'playwright-screenshots/page-examples-before-checks.png', fullPage: true });
-
-  // Check if the page does not contain the text "No results found."
-  const noResultsCount = await page.getByText(/No results found/).count();
-  console.log("Page contains 'No results found': ", noResultsCount)
-  expect(noResultsCount).toBe(0);
-
-  // Check if the page does not contain the text "No results found."
-  const searchFailedCount = await page.getByText(/External search command exited unexpectedly/).count();
-  console.log("Page contains 'External search command exited unexpectedly': ", searchFailedCount)
-  expect(searchFailedCount).toBe(0);
-
-  const { WAIT_FOR_HUMAN_TO_CHECK_IN_MS: waitForHumanStr} = process.env
-  const waitForHumanMs = parseInt(waitForHumanStr || '0');
-  console.log("Waiting for human for: ", waitForHumanMs);
-
-  await page.waitForTimeout(waitForHumanMs);
+  await waitForData(page, "examples");
 
   await page.screenshot({ path: 'playwright-screenshots/page-examples-after-checks.png', fullPage: true });
 });

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -73,7 +73,7 @@ setup('login and create account', async ({ page }) => {
     const { DATASET_URL: datasetUrl, DATASET_LOG_ACCESS_READ: datasetReadKey, DATASET_LOG_ACCESS_WRITE: datasetWriteKey } = process.env;
 
     // Fill in values
-    const accountName = 'QaTr' + (Math.random() * 1e18)
+    const accountName = 'E2ET' + (Math.random() * 1e18)
     console.log("Create account: ", accountName);
     await locAccount.fill(accountName);
     await locUrl.fill(datasetUrl || '');

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -55,7 +55,7 @@ setup('login and create account', async ({ page }) => {
   // wait for table to appear
   await page.getByText(/Account name/).click()
 
-  const accountCount = await page.getByRole("main").getByRole("row").getByText(/QaTr/).count();
+  const accountCount = await page.getByRole("main").getByRole("row").getByText(/E2ET/).count();
   console.log("Number of accounts: ", accountCount);
   if (accountCount == 0) {
     // Open dialog

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect, Page } from '@playwright/test';
+import { goToDataSet, goToSearch } from './utils';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+
+  await goToDataSet(page);
+  await goToSearch(page);
+});
+
+
+test('Simple search - dataset', async ({ page }) => {
+  await searchFor(page, "| dataset");
+
+  await page.screenshot({ path: 'playwright-screenshots/page-search-simple-search-dataset.png', fullPage: true });
+});
+
+test('Simple search - s1query', async ({ page }) => {
+  await searchFor(page, "| s1query");
+
+  await page.screenshot({ path: 'playwright-screenshots/page-search-simple-search-s1query.png', fullPage: true });
+});
+
+async function searchFor(page: Page, query: string, maxCount: number | undefined = undefined) {
+  if (maxCount === undefined) {
+    maxCount = Math.ceil(1000 * Math.random()) % 10 + 5;
+  }
+
+  const finalQuery = `${query} maxcount=${maxCount}`
+
+  console.log(`Searching for '${finalQuery}', original was: ${query}`);
+
+  await page.getByRole('textbox', { name: 'Search' }).fill(finalQuery);
+
+  await page.getByLabel("Search Button").click();
+
+  await expect(page.getByText(`Events (${maxCount})`)).toHaveCount(1);
+}

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,7 +1,47 @@
 import { Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 export async function goToDataSet(page: Page) {
     console.log("Go to DataSet page")
     await page.getByLabel('Navigate to Security Data Lake Add-On for Splunk app').click()
     await page.screenshot({ path: 'playwright-screenshots/page-home.png', fullPage: true });
+}
+
+export async function goToExamples(page: Page) {
+    console.log("Go to example page");
+    await page.getByText("DataSet by Example").click();
+
+    await expect(page).toHaveTitle(/DataSet by Example /);
+}
+
+export async function goToSearch(page: Page) {
+    console.log("Go to search page");
+    await page.getByRole('link', { name: 'Search' }).click();
+
+    await expect(page).toHaveTitle(/Search /);
+}
+
+export async function waitForData(page: Page, key: string) {
+    // Wait for the "Waiting for data..." text to disappear
+    console.log("Wait for 'Waiting for data' to disappear")
+    await page.screenshot({ path: `playwright-screenshots/page-${ key }-before-waiting-for-data.png`, fullPage: true });
+    await expect(page.getByText(/Waiting for data/)).toHaveCount(0, {timeout: 15000});
+
+    await page.screenshot({ path: `playwright-screenshots/page-${ key }-before-checks.png`, fullPage: true });
+
+    // Check if the page does not contain the text "No results found."
+    const noResultsCount = await page.getByText(/No results found/).count();
+    console.log("Page contains 'No results found': ", noResultsCount)
+    expect(noResultsCount).toBe(0);
+
+    // Check if the page does not contain the text "No results found."
+    const searchFailedCount = await page.getByText(/External search command exited unexpectedly/).count();
+    console.log("Page contains 'External search command exited unexpectedly': ", searchFailedCount)
+    expect(searchFailedCount).toBe(0);
+
+    const { WAIT_FOR_HUMAN_TO_CHECK_IN_MS: waitForHumanStr} = process.env
+    const waitForHumanMs = parseInt(waitForHumanStr || '0');
+    console.log("Waiting for human for: ", waitForHumanMs);
+
+    await page.waitForTimeout(waitForHumanMs);
 }


### PR DESCRIPTION
Jira Link: <https://sentinelone.atlassian.net/browse/DPDV-2608>

# 🥅 Goal

For some compatibility reasons we want to introduce s1query alias.

# 🛠️ Solution

1. Introduce alias for the autocomplete - https://docs.splunk.com/Documentation/Splunk/9.1.0/Admin/Searchbnfconf
2. Introduce new command - https://docs.splunk.com/Documentation/Splunk/9.1.0/Admin/Commandsconf

# 🏫 Testing

* I have introduced new test for search page - `npx playwright test --headed e2e/search.spec.ts`
* I have tested it manually - `| s1query maxcount=8` - 
<img width="792" alt="Screenshot 2023-08-15 at 10 02 40" src="https://github.com/scalyr/dataset-addon-for-splunk/assets/122797378/cc12b757-ef37-4537-8098-917aa0181ff7">

