### PR TITLE
DPDV-2719: Fix failing tests

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
-import { goToDataSet, goToSearch } from './utils';
+import { goToDataSet, goToSearch, waitForData } from './utils';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
@@ -33,6 +33,8 @@ async function searchFor(page: Page, query: string, maxCount: number | undefined
   await page.getByRole('textbox', { name: 'Search' }).fill(finalQuery);
 
   await page.getByLabel("Search Button").click();
+
+  await waitForData(page, query.replace(/[| )(_.,]/, ''))
 
   await expect(page.getByText(`Events (${maxCount})`)).toHaveCount(1);
 }

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 import { test, expect } from '@playwright/test';
 
 export async function goToDataSet(page: Page) {
@@ -21,23 +21,48 @@ export async function goToSearch(page: Page) {
     await expect(page).toHaveTitle(/Search /);
 }
 
-export async function waitForData(page: Page, key: string) {
-    // Wait for the "Waiting for data..." text to disappear
-    console.log("Wait for 'Waiting for data' to disappear")
-    await page.screenshot({ path: `playwright-screenshots/page-${ key }-before-waiting-for-data.png`, fullPage: true });
-    await expect(page.getByText(/Waiting for data/)).toHaveCount(0, {timeout: 15000});
+export async function waitForData(page: Page, key: string, locStopWaitingIfExists: Locator | undefined = undefined) {
+    await page.waitForTimeout(2000);
 
-    await page.screenshot({ path: `playwright-screenshots/page-${ key }-before-checks.png`, fullPage: true });
+    let pic = 0
 
-    // Check if the page does not contain the text "No results found."
-    const noResultsCount = await page.getByText(/No results found/).count();
-    console.log("Page contains 'No results found': ", noResultsCount)
-    expect(noResultsCount).toBe(0);
+    await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
 
-    // Check if the page does not contain the text "No results found."
-    const searchFailedCount = await page.getByText(/External search command exited unexpectedly/).count();
-    console.log("Page contains 'External search command exited unexpectedly': ", searchFailedCount)
-    expect(searchFailedCount).toBe(0);
+    for (let i = 0; i < 3; i++) {
+        console.log("Wait for 'Waiting for queued job to start' to disappear")
+        await expect(page.getByText(/Waiting for queued job to start/)).toHaveCount(0, {timeout: 50000})
+        await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
+
+        console.log("Wait for 'Waiting for data' to disappear")
+        await expect(page.getByText(/Waiting for data/)).toHaveCount(0, {timeout: 50000})
+        await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
+
+        console.log("Wait for 'No results yet found' to disappear")
+        await expect(page.getByText(/No results yet found/)).toHaveCount(0, {timeout: 50000})
+        await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
+
+        console.log("Wait for 'No results found' to disappear");
+        const locNoResults = page.getByText(/No results found/);
+        console.log("Text Content: " + await locNoResults.textContent());
+        console.log("Is Visible: " + await locNoResults.isVisible());
+        if (await locNoResults.isVisible()) {
+            await expect(locNoResults).toHaveCount(0, {timeout: 50000})
+            await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
+        }
+
+        if ( locStopWaitingIfExists !== undefined ) {
+            const count = await locStopWaitingIfExists.count()
+            console.log(`locStopWaitingIfExists: ${ count}`);
+            if (count > 0) {
+                break;
+            }
+        }
+        await page.waitForTimeout(2000);
+    }
+
+    console.log("Page contains 'External search command exited unexpectedly'")
+    await expect(page.getByText(/External search command exited unexpectedly/)).toHaveCount(0, {timeout: 50000});
+    await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
 
     const { WAIT_FOR_HUMAN_TO_CHECK_IN_MS: waitForHumanStr} = process.env
     const waitForHumanMs = parseInt(waitForHumanStr || '0');

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -21,43 +21,33 @@ export async function goToSearch(page: Page) {
     await expect(page).toHaveTitle(/Search /);
 }
 
-export async function waitForData(page: Page, key: string, locStopWaitingIfExists: Locator | undefined = undefined) {
-    await page.waitForTimeout(2000);
+export async function waitForData(page: Page, key: string) {
+    await page.waitForTimeout(5000);
 
     let pic = 0
 
     await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
 
-    for (let i = 0; i < 3; i++) {
-        console.log("Wait for 'Waiting for queued job to start' to disappear")
-        await expect(page.getByText(/Waiting for queued job to start/)).toHaveCount(0, {timeout: 50000})
-        await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
+    console.log("Wait for 'Waiting for queued job to start' to disappear")
+    await expect(page.getByText(/Waiting for queued job to start/)).toHaveCount(0, {timeout: 50000})
+    await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
 
-        console.log("Wait for 'Waiting for data' to disappear")
-        await expect(page.getByText(/Waiting for data/)).toHaveCount(0, {timeout: 50000})
-        await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
+    console.log("Wait for 'Waiting for data' to disappear")
+    await expect(page.getByText(/Waiting for data/)).toHaveCount(0, {timeout: 50000})
+    await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
 
-        console.log("Wait for 'No results yet found' to disappear")
-        await expect(page.getByText(/No results yet found/)).toHaveCount(0, {timeout: 50000})
-        await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
+    console.log("Wait for 'No results yet found' to disappear")
+    await expect(page.getByText(/No results yet found/)).toHaveCount(0, {timeout: 50000})
+    await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
 
-        console.log("Wait for 'No results found' to disappear");
-        const locNoResults = page.getByText(/No results found/);
-        console.log("Text Content: " + await locNoResults.textContent());
-        console.log("Is Visible: " + await locNoResults.isVisible());
+    // It looks that No results found element is still there, but not visible
+    console.log("Wait for 'No results found' to disappear");
+    const locNoResults = page.getByText(/No results found/);
+    if (await locNoResults.count() > 0) {
         if (await locNoResults.isVisible()) {
             await expect(locNoResults).toHaveCount(0, {timeout: 50000})
             await page.screenshot({ path: `playwright-screenshots/page-${ key }-wait-for-data-${ pic++ }.png`, fullPage: true });
         }
-
-        if ( locStopWaitingIfExists !== undefined ) {
-            const count = await locStopWaitingIfExists.count()
-            console.log(`locStopWaitingIfExists: ${ count}`);
-            if (count > 0) {
-                break;
-            }
-        }
-        await page.waitForTimeout(2000);
     }
 
     console.log("Page contains 'External search command exited unexpectedly'")

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export const STORAGE_STATE = pjoin(__dirname, 'e2e', '.auth.json');
 export default defineConfig({
   testDir: './e2e',
   /* Run tests in files in parallel */
-  fullyParallel: true,
+  fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
@@ -24,6 +24,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
+  timeout: 60000,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
Jira Link: <https://sentinelone.atlassian.net/browse/DPDV-2719>

# 🥅 Goal

When the tests were running in parallel and server responses were slow, there are other spinners before the final results are shown. So lets wait for them as well.

# 🛠️ Solution

Wait for more spinners.

# 🏫 Testing

Run `make e2e-test` few times.
