### PR TITLE
[DPDV-3505] [DPDV-3507] Fix failing Playwright e2e tests and add-on name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Since Splunk does not have [Docker image for Apple Sillicon](https://github.com/
 
 To clean up container run `docker container rm splunk` command
 
-## Install Security Data Lake Add-On for Splunk to running Docker container
+## Install Singularity Data Lake Add-On for Splunk to running Docker container
 Assuming application was previously built
 
 ### From existing release

--- a/TA_dataset/app.manifest
+++ b/TA_dataset/app.manifest
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "2.0.0",
   "info": {
-    "title": "Security Data Lake Add-On for Splunk",
+    "title": "Singularity Data Lake Add-On for Splunk",
     "id": {
       "group": null,
       "name": "TA_dataset",
@@ -15,7 +15,7 @@
       }
     ],
     "releaseDate": null,
-    "description": "The Security Data Lake Add-On for Splunk provides integration with DataSet by SentinelOne.",
+    "description": "The Singularity Data Lake Add-On for Splunk provides integration with DataSet by SentinelOne.",
     "classification": {
       "intendedAudience": "IT",
       "categories": [

--- a/e2e/deploy.spec.ts
+++ b/e2e/deploy.spec.ts
@@ -5,7 +5,7 @@ import {setTimeout} from 'timers/promises';
 test('Verify SDL addon is deployed properly', async ({page}) => {
     await page.goto('/');
     await page.screenshot({ path: 'playwright-screenshots/splunk-launcher-page.png', fullPage: true });
-    const sdlAddonLinks = page.getByLabel('Navigate to Security Data Lake Add-On for Splunk app');
+    const sdlAddonLinks = page.getByLabel('Navigate to Singularity Data Lake Add-On for Splunk app');
     await expect(sdlAddonLinks).toHaveCount(1);
 
     console.log("Go to DataSet page")
@@ -17,10 +17,23 @@ test('Verify SDL addon is deployed properly', async ({page}) => {
     const configLinks = page.getByRole('link', {name: 'Configuration'});
     await expect(configLinks).toHaveCount(1);
     await expect(configLinks.first()).toHaveAttribute('href','/en-US/app/TA_dataset/configuration');
-    const exampleLinks = page.getByRole('link', {name: 'DataSet by Example'});
-    await expect(exampleLinks).toHaveCount(1);
-    await expect(exampleLinks.first()).toHaveAttribute('href','/en-US/app/TA_dataset/dataset_by_example');
+
+    // Now that add-on contains multiple dashboards, they don't show under main menu item anymore, but
+    // under "Dashboards" meni item which on click opens a new menu bar
+    const dashboardsLinks = page.getByRole('link', {name: 'Dashboards'});
+    await expect(dashboardsLinks).toHaveCount(1);
+
     const searchLinks = page.getByRole('link', {name: 'Search'});
     await expect(searchLinks).toHaveCount(1);
     await expect(searchLinks.first()).toHaveAttribute('href','/en-US/app/TA_dataset/search');
+
+    // Verify all built-in dashboards are present
+    console.log("Go to Dashboards page");
+    await page.goto('/app/TA_dataset/dashboards');
+
+    await expect(page.getByRole('link', {name: 'Ingestion Summary'})).toHaveCount(1);
+    await expect(page.getByRole('link', {name: 'SentinelOne Use Case Query Examples'})).toHaveCount(1);
+    await expect(page.getByRole('link', {name: 'Singularity Data Lake by Example'})).toHaveCount(1);
+    await expect(page.getByRole('link', {name: 'SOC Search Examples'})).toHaveCount(1);
+    await expect(page.getByRole('link', {name: 'Splunk App Usage'})).toHaveCount(1);
 });

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -55,10 +55,9 @@ export async function goToDataSetConfigurationPage(page: Page) {
 
 export async function goToDataSetExamplesPage(page: Page) {
     console.log("Go to DataSet example page");
-    await page.goto('/app/TA_dataset/dataset_by_example');
-    await page.getByRole('link', { name: "DataSet by Example" }).click();
+    await page.goto('/app/TA_dataset/sdl_by_example');
 
-    await expect(page).toHaveTitle(/DataSet by Example/);
+    await expect(page).toHaveTitle(/Singularity Data Lake by Example/);
 
     await expectWithoutErrors(page);
 }

--- a/globalConfig.json
+++ b/globalConfig.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "name": "TA_dataset",
-    "displayName": "Security Data Lake Add-On for Splunk",
+    "displayName": "Singularity Data Lake Add-On for Splunk",
     "version": "2.0.45-SNAPSHOT",
     "restRoot": "TA_dataset",
     "schemaVersion": "0.0.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dataset-addon-for-splunk",
   "version": "1.0.0",
-  "description": "The Security Data Lake Add-On for Splunk provides integration with [DataSet](https://www.dataset.com) and [XDR](https://www.sentinelone.com/platform/xdr-ingestion) by [SentinelOne](https://sentinelone.com). The key functions allow two-way integration: - SPL custom command to query directly from the Splunk UI. - Inputs to index alerts as CIM-compliant, or any user-defined query results. - Alert action to send events from Splunk.",
+  "description": "The Singularity Data Lake Add-On for Splunk provides integration with [DataSet](https://www.dataset.com) and [XDR](https://www.sentinelone.com/platform/xdr-ingestion) by [SentinelOne](https://sentinelone.com). The key functions allow two-way integration: - SPL custom command to query directly from the Splunk UI. - Inputs to index alerts as CIM-compliant, or any user-defined query results. - Alert action to send events from Splunk.",
   "main": "index.js",
   "scripts": {
     "playwright": "playwright test",


### PR DESCRIPTION
This pull request includes the following changes:

### 1. Fix failing e2e tests

A couple of changes were merged recently (https://github.com/scalyr/dataset-addon-for-splunk/pull/82, https://github.com/scalyr/dataset-addon-for-splunk/pull/85) and those broke end to end tests.

This PR fixes all the failing tests and adds new checks for new built-in dashboards.

### 2. Fix Add-On Name

We have agreed on "Singularity Data Lake Add-On for Splunk" name, but some places still referenced "Security Data Lake Add-On for Splunk".

This PR fixes that and updates all the places to use "Singularity Data Lake Add-On for Splunk".