### PR TITLE
DPDV-4287: Pass the proxy settings

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -40,3 +40,19 @@ jobs:
             --input TA_dataset \
             --output output \
             --release release
+
+      - name: Store Release Folder
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: release
+          path: release
+          retention-days: 30
+
+      - name: Store Output Folder
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: output
+          path: output
+          retention-days: 30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,10 +125,14 @@ Note that build cleans previously created configuration. To prevent removal of c
 * Remove Splunk container - `make docker-splunk-remove`
 * Restore configuration - `make dev-config-backup`
 * Backup configuration - `make dev-config-restore` - it's not clear whether it really works
-* Tail Splunk logs - Splunkd - `make docker-tail-logs-splunk`
-* Tail Splunk logs - Python - `make docker-tail-logs-python`
-* Tail Splunk logs - Inputs - `make docker-tail-logs-inputs`
+* To see all available logs - `make docker-splunk-list-logs`
+* To see particular log, you may use - `make docker-splunk-tail-log LOG_NAME=log-file`
+  * Logs related to Splunk Python - `make docker-splunk-tail-logs-python` calls `make docker-splunk-tail-log LOG_NAME=python.log`
+  * Logs related to Search command - `make docker-splunk-tail-logs-app-search-command` calls `make docker-splunk-tail-log LOG_NAME="TA_dataset_search_command.log"`
 
+#### Where are errors:
+
+* `search_messages.log` - error message that is shown in the UI, no stack trace :/
 # E2E Testing
 
 We are using Playwright - https://playwright.dev/

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,7 @@ dev-config-restore:
 dev-update-source:
 	rsync -av $(SOURCE_PACKAGE)/bin/ $(OUTPUT_PACKAGE)/bin/
 	rsync -av $(SOURCE_PACKAGE)/default/ $(OUTPUT_PACKAGE)/default/
+	rsync -av $(SOURCE_PACKAGE)/lib/dataset_query_api_client/ $(OUTPUT_PACKAGE)/lib/dataset_query_api_client/
 
 dev-install-dependencies-pack:
 	pip install --upgrade-strategy only-if-needed -r requirements-pack.txt

--- a/Makefile
+++ b/Makefile
@@ -51,26 +51,34 @@ docker-splunk-show-app:
 		sudo -u splunk \
 		ls -l /opt/splunk/etc/apps/TA_dataset/
 
-.PHONY: docker-splunk-tail-logs-splunkd
-docker-splunk-tail-logs-splunkd:
+.PHONY: docker-splunk-list-logs
+docker-splunk-list-logs:
 	docker exec $(CONTAINER_NAME) \
 		sudo -u splunk \
-		tail -f \
-			/opt/splunk/var/log/splunk/splunkd.log
+		ls -lrt \
+			/opt/splunk/var/log/splunk/
+
+.PHONY: docker-splunk-tail-log
+docker-splunk-tail-log:
+	docker exec $(CONTAINER_NAME) \
+		bash -l -c "sudo -u splunk tail -f /opt/splunk/var/log/splunk/${LOG_NAME}"
+
+.PHONY: docker-splunk-tail-logs-splunkd
+docker-splunk-tail-logs-splunkd:
+	make docker-splunk-tail-log LOG_NAME=splunkd.log
 
 .PHONY: docker-splunk-tail-logs-python
 docker-splunk-tail-logs-python:
-	docker exec $(CONTAINER_NAME) \
-		sudo -u splunk \
-		tail -f \
-			/opt/splunk/var/log/splunk/python.log
+	make docker-splunk-tail-log LOG_NAME=python.log
 
-.PHONY: docker-splunk-tail-logs-input
-docker-splunk-tail-logs-input:
-	docker exec $(CONTAINER_NAME) \
-		sudo -u splunk \
-		tail -f \
-			/opt/splunk/var/log/splunk/TA_dataset_input.log
+# TODO: Figure out, how to make this work!
+.PHONY: docker-splunk-tail-logs-app-all
+docker-splunk-tail-logs-app-all:
+	make docker-splunk-tail-log LOG_NAME="TA_dataset*"
+
+.PHONY: docker-splunk-tail-logs-app-search-command
+docker-splunk-tail-logs-app-search-command:
+	make docker-splunk-tail-log LOG_NAME="TA_dataset_search_command.log"
 
 .PHONY: docker-splunk-tail-logs
 docker-splunk-tail-logs-count:
@@ -101,7 +109,7 @@ inspect:
 	splunk-appinspect inspect TA_dataset --included-tags splunk_appinspect
 
 .PHONY: pack
-pack:
+pack: clean
 	find $(SOURCE_PACKAGE) -name __pycache__ -exec rm -rfv {} \;
 	version=$$(jq -r '.meta.version' globalConfig.json) && \
 	scripts/pack.sh \
@@ -162,3 +170,7 @@ e2e-test-headed:
 	npm run playwright:headed
 e2e-test-ui:
 	npm run playwright:ui
+
+.PHONY: clean
+clean:
+	find $(SOURCE_PACKAGE) -name '.DS_Store' -exec rm -rfv {} \;

--- a/TA_dataset/bin/dataset_api.py
+++ b/TA_dataset/bin/dataset_api.py
@@ -25,8 +25,10 @@ from dataset_query_api_client.models import (
 
 
 # Executes Dataset LongRunningQuery for log events
-def ds_lrq_log_query(base_url, api_key, start_time, end_time, filter_expr, limit):
-    client = AuthenticatedClient(base_url=base_url, token=api_key)
+def ds_lrq_log_query(
+    base_url, api_key, start_time, end_time, filter_expr, limit, proxy
+):
+    client = AuthenticatedClient(base_url=base_url, token=api_key, proxy=proxy)
     body = PostQueriesLaunchQueryRequestBody(
         query_type=PostQueriesLaunchQueryRequestBodyQueryType.LOG,
         start_time=start_time,
@@ -37,8 +39,8 @@ def ds_lrq_log_query(base_url, api_key, start_time, end_time, filter_expr, limit
 
 
 # Executes Dataset LongRunningQuery using PowerQuery language
-def ds_lrq_power_query(base_url, api_key, start_time, end_time, query):
-    client = AuthenticatedClient(base_url=base_url, token=api_key)
+def ds_lrq_power_query(base_url, api_key, start_time, end_time, query, proxy):
+    client = AuthenticatedClient(base_url=base_url, token=api_key, proxy=proxy)
     body = PostQueriesLaunchQueryRequestBody(
         query_type=PostQueriesLaunchQueryRequestBodyQueryType.PQ,
         start_time=start_time,
@@ -50,9 +52,9 @@ def ds_lrq_power_query(base_url, api_key, start_time, end_time, query):
 
 # Executes Dataset LongRunningQuery to fetch facet values
 def ds_lrq_facet_values(
-    base_url, api_key, start_time, end_time, filter, name, max_values
+    base_url, api_key, start_time, end_time, filter, name, max_values, proxy
 ):
-    client = AuthenticatedClient(base_url=base_url, token=api_key)
+    client = AuthenticatedClient(base_url=base_url, token=api_key, proxy=proxy)
     body = PostQueriesLaunchQueryRequestBody(
         query_type=PostQueriesLaunchQueryRequestBodyQueryType.FACET_VALUES,
         start_time=start_time,
@@ -66,7 +68,9 @@ def ds_lrq_facet_values(
 
 # Executes LRQ run loop of launch-ping-remove API requests until the query completes
 # with a result
-def ds_lrq_run_loop(client, body: PostQueriesLaunchQueryRequestBody):
+def ds_lrq_run_loop(
+    client: AuthenticatedClient, body: PostQueriesLaunchQueryRequestBody
+):
     body.query_priority = PostQueriesLaunchQueryRequestBodyQueryPriority.HIGH
     response = post_queries.sync_detailed(client=client, json_body=body)
     result = response.parsed

--- a/TA_dataset/bin/dataset_api.py
+++ b/TA_dataset/bin/dataset_api.py
@@ -24,11 +24,26 @@ from dataset_query_api_client.models import (
 )
 
 
+# TODO: Convert to the expected format
+# https://www.python-httpx.org/advanced/#http-proxying
+def convert_proxy(proxy):
+    if not proxy:
+        return {}
+    new_proxy = {}
+    if "http" in proxy:
+        new_proxy["http://"] = proxy["http"]
+    if "https" in proxy:
+        new_proxy["https://"] = proxy["https"]
+    return new_proxy
+
+
 # Executes Dataset LongRunningQuery for log events
 def ds_lrq_log_query(
     base_url, api_key, start_time, end_time, filter_expr, limit, proxy
 ):
-    client = AuthenticatedClient(base_url=base_url, token=api_key, proxy=proxy)
+    client = AuthenticatedClient(
+        base_url=base_url, token=api_key, proxy=convert_proxy(proxy)
+    )
     body = PostQueriesLaunchQueryRequestBody(
         query_type=PostQueriesLaunchQueryRequestBodyQueryType.LOG,
         start_time=start_time,
@@ -40,7 +55,9 @@ def ds_lrq_log_query(
 
 # Executes Dataset LongRunningQuery using PowerQuery language
 def ds_lrq_power_query(base_url, api_key, start_time, end_time, query, proxy):
-    client = AuthenticatedClient(base_url=base_url, token=api_key, proxy=proxy)
+    client = AuthenticatedClient(
+        base_url=base_url, token=api_key, proxy=convert_proxy(proxy)
+    )
     body = PostQueriesLaunchQueryRequestBody(
         query_type=PostQueriesLaunchQueryRequestBodyQueryType.PQ,
         start_time=start_time,
@@ -54,7 +71,9 @@ def ds_lrq_power_query(base_url, api_key, start_time, end_time, query, proxy):
 def ds_lrq_facet_values(
     base_url, api_key, start_time, end_time, filter, name, max_values, proxy
 ):
-    client = AuthenticatedClient(base_url=base_url, token=api_key, proxy=proxy)
+    client = AuthenticatedClient(
+        base_url=base_url, token=api_key, proxy=convert_proxy(proxy)
+    )
     body = PostQueriesLaunchQueryRequestBody(
         query_type=PostQueriesLaunchQueryRequestBodyQueryType.FACET_VALUES,
         start_time=start_time,

--- a/TA_dataset/bin/dataset_common.py
+++ b/TA_dataset/bin/dataset_common.py
@@ -102,23 +102,28 @@ def get_proxy(session_key, logger):
         if int(proxy_enabled) == 0:
             return None
         else:
+            proxy_type = proxy_details.get("proxy_type")
             proxy_host = proxy_details.get("proxy_url")
             proxy_port = proxy_details.get("proxy_port")
             proxy_username = proxy_details.get("proxy_username")
             proxy_password = proxy_details.get("proxy_password")
             proxies = {}
             proxy_url = ""
+            if proxy_type:
+                proxy_url += proxy_type
+            else:
+                proxy_url += "http"
+            proxy_url += "://"
             if proxy_username:
                 proxy_url += proxy_username
             if proxy_password:
                 proxy_url += ":" + proxy_password
             if proxy_username:
                 proxy_url += "@"
-            proxy_url += proxy_host + ":" + proxy_port
+            proxy_url += proxy_host
+            proxy_url += ":" + proxy_port
 
-            # TODO: We are only supporting HTTP proxies
-            # Is this expected?
-            proxies["http"] = "http://" + proxy_url
+            proxies["http"] = proxy_url
             proxies["https"] = proxies["http"]
 
             return proxies

--- a/TA_dataset/bin/dataset_common.py
+++ b/TA_dataset/bin/dataset_common.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 import json
+import logging
 import os.path as op
 import sys
 import time
 
 # adjust paths to make the Splunk app working
 import import_declare_test  # noqa: F401
-from solnlib import conf_manager
+from solnlib import conf_manager, log
 
 APP_NAME = __file__.split(op.sep)[-3]
 CONF_NAME = "ta_dataset"
@@ -26,6 +27,15 @@ def get_url(base_url, ds_method):
         ds_api_endpoint = "addEvents"
 
     return base_url + "/api/" + ds_api_endpoint
+
+
+# returns logger that logs data into file
+# /opt/splunk/var/log/splunk/${APP_NAME}/${suffix}
+def get_logger(session_key, suffix: str):
+    logger = log.Logs().get_logger("{}_{}".format(APP_NAME, suffix))
+    log_level = get_log_level(session_key, logging)
+    logger.setLevel(log_level)
+    return logger
 
 
 # one conf manager to rule them all

--- a/TA_dataset/bin/dataset_common.py
+++ b/TA_dataset/bin/dataset_common.py
@@ -94,7 +94,6 @@ def get_proxy(session_key, logger):
             # MM: it does not have key `proxy_enabled, it has key - disabled
             #  {'disabled': '0', 'eai:appName': 'TA_dataset' ...
             proxy_details = cfm.get_conf(CONF_NAME + "_settings").get("proxy")
-            logger.info("MM PROXY: " + repr(proxy_details))
             proxy_enabled = proxy_details.get("proxy_enabled", 0)
         except Exception as e:
             logger.debug("No proxy information defined: {}".format(e))
@@ -103,30 +102,25 @@ def get_proxy(session_key, logger):
         if int(proxy_enabled) == 0:
             return None
         else:
-            proxy_url = proxy_details.get("proxy_url")
+            proxy_host = proxy_details.get("proxy_url")
             proxy_port = proxy_details.get("proxy_port")
             proxy_username = proxy_details.get("proxy_username")
             proxy_password = proxy_details.get("proxy_password")
-            proxy_type = proxy_details.get("proxy_type")
             proxies = {}
-            if proxy_username and proxy_password:
-                proxies["http"] = (
-                    proxy_username
-                    + ":"
-                    + proxy_password
-                    + "@"
-                    + proxy_url
-                    + ":"
-                    + proxy_port
-                )
-            elif proxy_username:
-                proxies["http"] = proxy_username + "@" + proxy_url + ":" + proxy_port
-            else:
-                proxies["http"] = proxy_url + ":" + proxy_port
-            if proxy_type and proxy_type != "http":
-                proxies["http"] = proxy_type + "://" + proxies["http"]
+            proxy_url = ""
+            if proxy_username:
+                proxy_url += proxy_username
+            if proxy_password:
+                proxy_url += ":" + proxy_password
+            if proxy_username:
+                proxy_url += "@"
+            proxy_url += proxy_host + ":" + proxy_port
 
+            # TODO: We are only supporting HTTP proxies
+            # Is this expected?
+            proxies["http"] = "http://" + proxy_url
             proxies["https"] = proxies["http"]
+
             return proxies
 
     except Exception as e:

--- a/TA_dataset/bin/dataset_query.py
+++ b/TA_dataset/bin/dataset_query.py
@@ -14,13 +14,12 @@ import requests
 from dataset_api import build_payload, get_maxcount, parse_query, query_api_max
 from dataset_common import (
     get_acct_info,
-    get_log_level,
+    get_logger,
     get_proxy,
     get_url,
     relative_to_epoch,
 )
 from dataset_query_api_client.client import get_user_agent
-from solnlib import log
 from solnlib.modular_input import checkpointer
 from splunklib import modularinput as smi
 
@@ -115,11 +114,7 @@ class DATASET_QUERY_INPUT(smi.Script):
 
         # Generate logger with input name
         _, input_name = input_name.split("//", 2)
-        logger = log.Logs().get_logger("{}_input".format(APP_NAME))
-
-        # Log level configuration
-        log_level = get_log_level(session_key, logger)
-        logger.setLevel(log_level)
+        logger = get_logger(session_key, "input")
 
         logger.debug("Modular input invoked.")
 

--- a/TA_dataset/bin/dataset_search_command.py
+++ b/TA_dataset/bin/dataset_search_command.py
@@ -313,7 +313,7 @@ class DataSetSearch(GeneratingCommand):
                         limit=ds_maxcount,
                         proxy=proxy,
                     )
-                    logger.info("QUERY RESULT, result={}".format(result))
+                    logger.debug("QUERY RESULT, result={}".format(result))
 
                     matches_list = result.data.matches  # List<LogEvent>
 
@@ -355,7 +355,7 @@ class DataSetSearch(GeneratingCommand):
                         query=pq,
                         proxy=proxy,
                     )
-                    logger.info("QUERY RESULT, result={}".format(result))
+                    logger.debug("QUERY RESULT, result={}".format(result))
                     data = result.data  # TableResultData
                     columns = data.columns
                     for row in data.values:
@@ -391,7 +391,7 @@ class DataSetSearch(GeneratingCommand):
                         max_values=ds_maxcount,
                         proxy=proxy,
                     )
-                    logger.info("QUERY RESULT, result={}".format(result))
+                    logger.debug("QUERY RESULT, result={}".format(result))
                     facet = result.data.facet  # FacetValuesResultData.data -> FacetData
                     values = facet.values  # List[FacetValue]
                     for i in range(len(values)):

--- a/TA_dataset/bin/dataset_search_command.py
+++ b/TA_dataset/bin/dataset_search_command.py
@@ -21,7 +21,13 @@ from dataset_api import (
     get_maxcount,
     parse_splunk_dt,
 )
-from dataset_common import get_acct_info, get_proxy, get_url, relative_to_epoch
+from dataset_common import (
+    get_acct_info,
+    get_logger,
+    get_proxy,
+    get_url,
+    relative_to_epoch,
+)
 
 # Dataset V2 API client (generated)
 from dataset_query_api_client.client import get_user_agent
@@ -270,8 +276,11 @@ class DataSetSearch(GeneratingCommand):
             ts_create_summ,
             ts_use_summ,
         )
-        proxy = get_proxy(self.service.token, logging)
-        acct_dict = get_acct_info(self, logging, ds_account)
+
+        logger = get_logger(self.service.token, "search_command")
+
+        proxy = get_proxy(self.service.token, logger)
+        acct_dict = get_acct_info(self, logger, ds_account)
         if acct_dict is None:
             search_error_exit(
                 self, "Account token error, review search log for details"
@@ -302,14 +311,15 @@ class DataSetSearch(GeneratingCommand):
                         end_time=ds_end,
                         filter_expr=ds_search,
                         limit=ds_maxcount,
+                        proxy=proxy,
                     )
-                    logging.info("QUERY RESULT, result={}".format(result))
+                    logger.info("QUERY RESULT, result={}".format(result))
 
                     matches_list = result.data.matches  # List<LogEvent>
 
                     if len(matches_list) == 0:
-                        logging.warning("DataSet response success, no matches returned")
-                        # logging.warning(r_json)
+                        logger.warning("DataSet response success, no matches returned")
+                        # logger.warning(r_json)
 
                     for event in matches_list:
                         ds_event = json.loads(
@@ -328,7 +338,7 @@ class DataSetSearch(GeneratingCommand):
                             account=ds_acct,
                             _raw=ds_event,
                         )
-                    logging.debug(
+                    logger.debug(
                         "DataSetFunction=completeEvents, startTime={}".format(
                             time.time()
                         )
@@ -336,15 +346,16 @@ class DataSetSearch(GeneratingCommand):
                     GeneratingCommand.flush
                 elif ds_method == "powerquery":
                     pq = ds_build_pq(ds_search, ds_columns, ds_maxcount)
-                    logging.info("PQ: {}".format(pq))
+                    logger.info("PQ: {}".format(pq))
                     result = ds_lrq_power_query(
                         base_url=ds_base_url,
                         api_key=ds_api_key,
                         start_time=ds_start,
                         end_time=ds_end,
                         query=pq,
+                        proxy=proxy,
                     )
-                    logging.info("QUERY RESULT, result={}".format(result))
+                    logger.info("QUERY RESULT, result={}".format(result))
                     data = result.data  # TableResultData
                     columns = data.columns
                     for row in data.values:
@@ -362,7 +373,7 @@ class DataSetSearch(GeneratingCommand):
                             _raw=ds_event,
                         )
 
-                    logging.debug(
+                    logger.debug(
                         "DataSetFunction=completeEvents, startTime={}".format(
                             time.time()
                         )
@@ -378,8 +389,9 @@ class DataSetSearch(GeneratingCommand):
                         filter=ds_search,
                         name=f_field,
                         max_values=ds_maxcount,
+                        proxy=proxy,
                     )
-                    logging.info("QUERY RESULT, result={}".format(result))
+                    logger.info("QUERY RESULT, result={}".format(result))
                     facet = result.data.facet  # FacetValuesResultData.data -> FacetData
                     values = facet.values  # List[FacetValue]
                     for i in range(len(values)):
@@ -396,7 +408,7 @@ class DataSetSearch(GeneratingCommand):
                             _raw=ds_event,
                         )
 
-                    logging.debug(
+                    logger.debug(
                         "DataSetFunction=completeEvents, startTime={}".format(
                             time.time()
                         )
@@ -406,14 +418,14 @@ class DataSetSearch(GeneratingCommand):
                     # TODO: There is no equivalent to the old timeseries API in
                     #  the new async version, but we can look into replacing this
                     #  with a PLOT query type
-                    logging.debug(
+                    logger.debug(
                         "DataSetFunction=makeRequest, destination={}, startTime={}"
                         .format(ds_url, time.time())
                     )
                     r = requests.post(
                         url=ds_url, headers=ds_headers, json=ds_payload, proxies=proxy
                     )
-                    logging.debug(
+                    logger.debug(
                         "DataSetFunction=getResponse, elapsed={}".format(r.elapsed)
                     )
                     r_json = r.json()
@@ -443,16 +455,16 @@ class DataSetSearch(GeneratingCommand):
                             yield record
 
                     else:
-                        logging.warning("DataSet response success, no matches returned")
+                        logger.warning("DataSet response success, no matches returned")
 
-                    logging.debug(
+                    logger.debug(
                         "DataSetFunction=completeEvents, startTime={}".format(
                             time.time()
                         )
                     )
                     GeneratingCommand.flush
                 else:
-                    logging.debug(
+                    logger.debug(
                         "DataSetFunction=completeEvents, startTime={}".format(
                             time.time()
                         )

--- a/TA_dataset/lib/dataset_query_api_client/api/default/delete_queries.py
+++ b/TA_dataset/lib/dataset_query_api_client/api/default/delete_queries.py
@@ -19,6 +19,7 @@ def _get_kwargs(
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()
+    proxies: Dict[str, str] = client.get_proxy()
 
     headers["x-dataset-query-forward-tag"] = forward_tag
 
@@ -27,6 +28,7 @@ def _get_kwargs(
         "url": url,
         "headers": headers,
         "cookies": cookies,
+        "proxies": proxies,
         "timeout": client.get_timeout(),
         "follow_redirects": client.follow_redirects,
     }

--- a/TA_dataset/lib/dataset_query_api_client/api/default/get_queries.py
+++ b/TA_dataset/lib/dataset_query_api_client/api/default/get_queries.py
@@ -25,6 +25,7 @@ def _get_kwargs(
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()
+    proxies: Dict[str, str] = client.get_proxy()
 
     params: Dict[str, Any] = {}
     params["lastStepSeen"] = last_step_seen
@@ -38,6 +39,7 @@ def _get_kwargs(
         "url": url,
         "headers": headers,
         "cookies": cookies,
+        "proxies": proxies,
         "timeout": client.get_timeout(),
         "follow_redirects": client.follow_redirects,
         "params": params,

--- a/TA_dataset/lib/dataset_query_api_client/api/default/post_queries.py
+++ b/TA_dataset/lib/dataset_query_api_client/api/default/post_queries.py
@@ -26,6 +26,7 @@ def _get_kwargs(
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()
+    proxies: Dict[str, str] = client.get_proxy()
 
     json_json_body = json_body.to_dict()
 
@@ -34,6 +35,7 @@ def _get_kwargs(
         "url": url,
         "headers": headers,
         "cookies": cookies,
+        "proxies": proxies,
         "timeout": client.get_timeout(),
         "follow_redirects": client.follow_redirects,
         "json": json_json_body,

--- a/TA_dataset/lib/dataset_query_api_client/client.py
+++ b/TA_dataset/lib/dataset_query_api_client/client.py
@@ -16,8 +16,8 @@ class Client:
     Attributes:
         base_url: The base URL for the API, all requests are made to a relative path to this URL
         cookies: A dictionary of cookies to be sent with every request
-        headers: A dictionary of proxy settings to be used for every request
-        headers: A dictionary of headers to be sent with every request
+        headers: A dictionary of headers settings to be used for every request
+        proxy: A dictionary of proxy to be sent with every request
         timeout: The maximum amount of a time in seconds a request can take. API functions will raise
             httpx.TimeoutException if this is exceeded.
         verify_ssl: Whether to verify the SSL certificate of the API server. This should be True in production,

--- a/TA_dataset/lib/dataset_query_api_client/client.py
+++ b/TA_dataset/lib/dataset_query_api_client/client.py
@@ -16,24 +16,25 @@ class Client:
     Attributes:
         base_url: The base URL for the API, all requests are made to a relative path to this URL
         cookies: A dictionary of cookies to be sent with every request
+        headers: A dictionary of proxy settings to be used for every request
         headers: A dictionary of headers to be sent with every request
         timeout: The maximum amount of a time in seconds a request can take. API functions will raise
             httpx.TimeoutException if this is exceeded.
-        verify_ssl: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        verify_ssl: Whether to verify the SSL certificate of the API server. This should be True in production,
             but can be set to False for testing purposes.
-        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+        raise_on_unexpected_status: Whether to raise an errors.UnexpectedStatus if the API returns a
             status code that was not documented in the source OpenAPI document.
-        follow_redirects: Whether or not to follow redirects. Default value is False.
+        follow_redirects: Whether to follow redirects. Default value is False.
     """
 
     base_url: str
     cookies: Dict[str, str] = attr.ib(factory=dict, kw_only=True)
     headers: Dict[str, str] = attr.ib(factory=dict, kw_only=True)
+    proxy: Dict[str, str] = attr.ib(factory=dict, kw_only=True)
     timeout: float = attr.ib(5.0, kw_only=True)
     verify_ssl: Union[str, bool, ssl.SSLContext] = attr.ib(True, kw_only=True)
     raise_on_unexpected_status: bool = attr.ib(False, kw_only=True)
     follow_redirects: bool = attr.ib(False, kw_only=True)
-    proxy: Dict[str, str] = attr.ib(factory=dict, kw_only=True)
 
     def get_headers(self) -> Dict[str, str]:
         """Get headers to be used in all endpoints"""

--- a/TA_dataset/lib/dataset_query_api_client/client.py
+++ b/TA_dataset/lib/dataset_query_api_client/client.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Dict, Union
 
 import attr
+import httpx
 import requests
 
 
@@ -32,6 +33,7 @@ class Client:
     verify_ssl: Union[str, bool, ssl.SSLContext] = attr.ib(True, kw_only=True)
     raise_on_unexpected_status: bool = attr.ib(False, kw_only=True)
     follow_redirects: bool = attr.ib(False, kw_only=True)
+    proxy: Dict[str, str] = attr.ib(factory=dict, kw_only=True)
 
     def get_headers(self) -> Dict[str, str]:
         """Get headers to be used in all endpoints"""
@@ -55,6 +57,13 @@ class Client:
         """Get a new client matching this one with a new timeout (in seconds)"""
         return attr.evolve(self, timeout=timeout)
 
+    def get_proxy(self) -> Dict[str, str]:
+        return {**self.proxy}
+
+    def with_proxy(self, proxy: Dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        return attr.evolve(self, proxy={**self.proxy, **proxy})
+
 
 def get_user_agent():
     """Get user agent"""
@@ -74,12 +83,13 @@ def get_user_agent():
     )
     splunk_version = extract(splunk_version_file)
 
-    return "dataset-splunk-addon;{};{};python-{};splunk-{};requests-{}".format(
+    return "dataset-splunk-addon;{};{};python-{};splunk-{};requests-{},httpx-{}".format(
         version,
         platform.platform(),
         platform.python_version(),
         splunk_version,
         requests.__version__,
+        httpx.__version__,
     )
 
 

--- a/globalConfig.json
+++ b/globalConfig.json
@@ -150,6 +150,21 @@
               "type": "checkbox"
             },
             {
+              "type": "singleSelect",
+              "label": "Proxy Type",
+              "options": {
+                "disableSearch": true,
+                "autoCompleteFields": [
+                  {
+                    "value": "http",
+                    "label": "http"
+                  }
+                ]
+              },
+              "defaultValue": "http",
+              "field": "proxy_type"
+            },
+            {
               "field": "proxy_url",
               "label": "Host",
               "type": "text",


### PR DESCRIPTION
Jira Link: <https://sentinelone.atlassian.net/browse/DPDV-4287>

# 🥅 Goal

Pass the proxy configuration to the library responsible for API calls.


# 🛠️ Solution

Pass the proxy configuration to the client, so that it be used for API calls.

This PR is also changing the logging of the single API call, so that the logs are available. When `logging` was used, they were not visible in logs.

# 🏫 Testing

* Use local proxy: 
  * Run proxy as docker - https://github.com/abhinavsingh/proxy.py - `docker run -it -p 8899:8899 --rm abhinavsingh/proxy.py:latest --log-level d --hostname 0.0.0.0`
* Proxy with basic auth - `docker run -it -p 8899:8899 --rm abhinavsingh/proxy.py:latest --log-level d --hostname 0.0.0.0 --basic-auth "foo:bar"`
* 
<img width="492" alt="Screenshot 2023-10-30 at 10 13 11" src="https://github.com/scalyr/dataset-addon-for-splunk/assets/122797378/d1826231-149f-4a08-84bb-1852cf840395">


* First 3 examples are using - `httpx` - and this is the fix, the 4th example is still using `requests` - everything is working.
<img width="505" src="https://github.com/scalyr/dataset-addon-for-splunk/assets/122797378/0886933f-e56a-41fd-bb62-16bb002eb371">

* I have used search to check that all places are replaces - ![Screenshot 2023-10-26 at 17 03 17](https://github.com/scalyr/dataset-addon-for-splunk/assets/122797378/722aa450-f3b6-4257-9ef0-64bbde7144a7)

# ❓ Question

It looks that we are always using http proxy even when maybe https should be used?