### PR TITLE
Check dependencies in the lib folder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     schedule:
       interval: "daily"
 
+  - package-ecosystem: "pip"
+    directory: "/TA_dataset/lib/"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
It looks that we are not checking the `TA_dataset/lib/requirements.txt` with dependabot. So let's fix this.

https://github.com/scalyr/dataset-addon-for-splunk/network/updates

<img width="355" alt="Screenshot 2023-10-30 at 12 27 38" src="https://github.com/scalyr/dataset-addon-for-splunk/assets/122797378/9e465d86-48b6-4fa1-8c2e-7f8a910eb98e">
<img width="1060" alt="Screenshot 2023-10-30 at 12 25 17" src="https://github.com/scalyr/dataset-addon-for-splunk/assets/122797378/bda7f034-33e7-4a29-9116-34142e812955">
