### PR TITLE
Add instructions about release procedure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,15 +113,23 @@ Note that build cleans previously created configuration. To prevent removal of c
 #### Alternative Build and Run Workflow for Docker using make commands
 
 1. At the beginning of the day:
-   1. Create package - `make pack`
-   2. Run Splunk in Docker - `make docker-splunk-run` (if it already exists use `make docker-splunk-start`)
+   1. Remove non-running container - `make docker-splunk-remove`
+   2. Create package - `make pack`
+   3. Run Splunk in Docker - `make docker-splunk-run` (if it already exists use `make docker-splunk-start`)
+   4. You can combine this into - `make docker-splunk-remove pack docker-splunk-run`
 2. Do your code changes (assuming docker is already running, see previous steps):
    1. Update source code - `make dev-update-source`
 
+You have to do 1. when you are changing other files (matadata, assets, ...). If the container is still running, you can
+use `make docker-splunk-kill`.
+
 #### Other Useful Commands
 
+* Run Splunk without DataSet Add-On - `make docker-splunk-run-vanilla`
 * Restart Splunk - `make docker-splunk-restart`
-* Stop Splunk - `make docker-splunk-restart`
+* Stop Splunk - `make docker-splunk-stop`
+* Start stopped Splunk container - `make docker-splunk-start`
+* Kill Splunk container - `make docker-splunk-kill`
 * Remove Splunk container - `make docker-splunk-remove`
 * Restore configuration - `make dev-config-backup`
 * Backup configuration - `make dev-config-restore` - it's not clear whether it really works

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,8 +159,8 @@ new version by following these instructions:
 2. Click on [Draft new release](https://github.com/scalyr/dataset-addon-for-splunk/releases/new).
 3. Create new release by:
    1. Pick the latest tag.
-   2. As previous tag pick the tag of the latest release from 1.
+   2. As previous tag pick the tag of the latest release from 1. ![dataset-addon-for-splunk-begin](https://github.com/scalyr/dataset-addon-for-splunk/assets/122797378/c53af6ce-7066-47cc-93a5-cdd14d5cedb5)
    3. Click on `Generate release notes`.
    4. Upload the file from the [release](release) folder - `TA_dataset-x.y.z.tar.gz`.
    5. Append some short description to the Release title.
-4. Click on `Publish release`.
+4. Click on `Publish release`. ![dataset-addon-for-splunk-end](https://github.com/scalyr/dataset-addon-for-splunk/assets/122797378/6601fb40-619e-411f-8bdf-9401d1b66eda)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,3 +148,19 @@ We are using Playwright - https://playwright.dev/
 * Make sure, that your Splunk is running - `make docker-splunk-run`
 * Use `make e2e-test` - to run e2e tests without the browser
 * Use `make e2e-test-headed` - to run e2e tests with the browser
+
+# Release
+
+When code is merged, new tag is created and content of the [release](release)
+folder is updated with the tarball containing the latest version. You can release
+new version by following these instructions:
+
+1. Go to [Releases](https://github.com/scalyr/dataset-addon-for-splunk/releases) and remember what was the latest version released.
+2. Click on [Draft new release](https://github.com/scalyr/dataset-addon-for-splunk/releases/new).
+3. Create new release by:
+   1. Pick the latest tag.
+   2. As previous tag pick the tag of the latest release from 1.
+   3. Click on `Generate release notes`.
+   4. Upload the file from the [release](release) folder - `TA_dataset-x.y.z.tar.gz`.
+   5. Append some short description to the Release title.
+4. Click on `Publish release`.

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,15 @@ docker-splunk-run-shared:
 		-p 8000:8000 \
 		splunk/splunk:9.1 start
 
+docker-splunk-run-vanilla:
+	docker run -it \
+		-e SPLUNK_START_ARGS=--accept-license \
+		-e SPLUNK_PASSWORD=Test0101 \
+		--platform=linux/amd64 \
+		--name $(CONTAINER_NAME) \
+		-p 8000:8000 \
+		splunk/splunk:9.1 start
+
 .PHONY: docker-splunk-start
 docker-splunk-start:
 	docker start -a $(CONTAINER_NAME)


### PR DESCRIPTION
# 🥅 Goal

Add instructions about the release procedure.

# 🛠️ Solution

Instructions are added:

When code is merged, new tag is created and content of the [release](release)
folder is updated with the tarball containing the latest version. You can release
new version by following these instructions:

1. Go to [Releases](https://github.com/scalyr/dataset-addon-for-splunk/releases) and remember what was the latest version released.
2. Click on [Draft new release](https://github.com/scalyr/dataset-addon-for-splunk/releases/new).
3. Create new release by:
   1. Pick the latest tag.
   2. As previous tag pick the tag of the latest release from 1.
   3. Click on `Generate release notes`.
   4. Upload the file from the [release](release) folder - `TA_dataset-x.y.z.tar.gz`.
   5. Append some short description to the Release title.
4. Click on `Publish release`.


![dataset-addon-for-splunk-end](https://github.com/scalyr/dataset-addon-for-splunk/assets/122797378/6601fb40-619e-411f-8bdf-9401d1b66eda)
![dataset-addon-for-splunk-begin](https://github.com/scalyr/dataset-addon-for-splunk/assets/122797378/c53af6ce-7066-47cc-93a5-cdd14d5cedb5)

# 🏫 Testing

Check the instructions.
